### PR TITLE
Extend Numbers field, various improvements

### DIFF
--- a/src/Units.php
+++ b/src/Units.php
@@ -142,12 +142,13 @@ class Units extends Plugin
     protected function settingsHtml(): string
     {
         $unitsClassMap = array_flip(ClassHelper::getClassesInNamespace(Length::class));
+
         return Craft::$app->view->renderTemplate(
             'units/settings',
             [
                 'settings' => $this->getSettings(),
-                 'unitsClassMap' => $unitsClassMap,
-           ]
+                'unitsClassMap' => $unitsClassMap,
+            ]
         );
     }
 }

--- a/src/Units.php
+++ b/src/Units.php
@@ -10,22 +10,22 @@
 
 namespace nystudio107\units;
 
+use Craft;
+use craft\base\Plugin;
+use craft\events\PluginEvent;
+use craft\events\RegisterComponentTypesEvent;
+
+use craft\services\Fields;
+use craft\services\Plugins;
+use craft\web\twig\variables\CraftVariable;
 use nystudio107\units\fields\Units as UnitsField;
 use nystudio107\units\helpers\ClassHelper;
 use nystudio107\units\models\Settings;
 use nystudio107\units\variables\UnitsVariable;
 
-use Craft;
-use craft\base\Plugin;
-use craft\events\PluginEvent;
-use craft\events\RegisterComponentTypesEvent;
-use craft\services\Fields;
-use craft\services\Plugins;
-use craft\web\twig\variables\CraftVariable;
+use PhpUnitsOfMeasure\PhysicalQuantity\Length;
 
 use yii\base\Event;
-
-use PhpUnitsOfMeasure\PhysicalQuantity\Length;
 
 /**
  * Class Units

--- a/src/Units.php
+++ b/src/Units.php
@@ -103,7 +103,7 @@ class Units extends Plugin
                 $field = $event->sender;
 
                 if (!$field instanceof UnitsField) {
-                  return;
+                    return;
                 }
 
                 $object = $event->schema->createObjectType(ucfirst($field->handle) . 'Units');

--- a/src/assetbundles/unitsfield/dist/css/Units.css
+++ b/src/assetbundles/unitsfield/dist/css/Units.css
@@ -10,10 +10,12 @@
  * @since     1.0.0
  */
 
-.units-field-units {
-    margin: -20px 9px;
+/* restrict to container on narrow widths */
+.units-field-units-select select {
+  width: 100%;
 }
 
-.units-field-units-select {
-    margin: -16px 0px;
+/* Prevent double margin and align prefix, suffix, field, and unit */
+.units-field .flex:not(.flex-nowrap) > * {
+  margin-bottom: 0;
 }

--- a/src/fields/Units.php
+++ b/src/fields/Units.php
@@ -11,25 +11,23 @@
 
 namespace nystudio107\units\fields;
 
-use nystudio107\units\assetbundles\unitsfield\UnitsFieldAsset;
+use Craft;
+use craft\base\ElementInterface;
+use craft\base\PreviewableFieldInterface;
+use craft\fields\Number;
+use craft\helpers\Json;
+use craft\i18n\Locale;
 
+use nystudio107\units\assetbundles\unitsfield\UnitsFieldAsset;
 use nystudio107\units\helpers\ClassHelper;
 use nystudio107\units\models\Settings;
 use nystudio107\units\models\UnitsData;
 use nystudio107\units\Units as UnitsPlugin;
 use nystudio107\units\validators\EmbeddedUnitsDataValidator;
 
-use Craft;
-use craft\base\ElementInterface;
-use craft\base\Field;
-use craft\base\PreviewableFieldInterface;
-use craft\helpers\Json;
-use craft\i18n\Locale;
+use PhpUnitsOfMeasure\PhysicalQuantity\Length;
 
 use yii\base\InvalidConfigException;
-
-use PhpUnitsOfMeasure\AbstractPhysicalQuantity;
-use PhpUnitsOfMeasure\PhysicalQuantity\Length;
 
 /**
  * @author    nystudio107

--- a/src/fields/Units.php
+++ b/src/fields/Units.php
@@ -34,7 +34,7 @@ use yii\base\InvalidConfigException;
  * @package   Units
  * @since     1.0.0
  */
-class Units extends Field implements PreviewableFieldInterface
+class Units extends Number implements PreviewableFieldInterface
 {
     // Static Methods
     // =========================================================================
@@ -56,11 +56,6 @@ class Units extends Field implements PreviewableFieldInterface
     public $defaultUnitsClass;
 
     /**
-     * @var float The default value of the unit of measure
-     */
-    public $defaultValue;
-
-    /**
      * @var string The default units that the unit of measure is in
      */
     public $defaultUnits;
@@ -69,26 +64,6 @@ class Units extends Field implements PreviewableFieldInterface
      * @var bool Whether the units the field can be changed
      */
     public $changeableUnits;
-
-    /**
-     * @var int|float The minimum allowed number
-     */
-    public $min;
-
-    /**
-     * @var int|float|null The maximum allowed number
-     */
-    public $max;
-
-    /**
-     * @var int The number of digits allowed after the decimal point
-     */
-    public $decimals;
-
-    /**
-     * @var int|null The size of the field
-     */
-    public $size;
 
     // Public Methods
     // =========================================================================
@@ -131,22 +106,9 @@ class Units extends Field implements PreviewableFieldInterface
         $rules = parent::rules();
         $rules = array_merge($rules, [
             ['defaultUnitsClass', 'string'],
-            ['defaultValue', 'number'],
             ['defaultUnits', 'string'],
             ['changeableUnits', 'boolean'],
-            [['min', 'max'], 'number'],
-            [['decimals', 'size'], 'integer'],
-            [
-                ['max'],
-                'compare',
-                'compareAttribute' => 'min',
-                'operator' => '>=',
-            ],
         ]);
-
-        if (!$this->decimals) {
-            $rules[] = [['min', 'max'], 'integer'];
-        }
 
         return $rules;
     }
@@ -156,6 +118,8 @@ class Units extends Field implements PreviewableFieldInterface
      */
     public function normalizeValue($value, ElementInterface $element = null)
     {
+        $value = parent::normalizeValue($value, $element);
+
         if ($value instanceof UnitsData) {
             return $value;
         }
@@ -169,16 +133,15 @@ class Units extends Field implements PreviewableFieldInterface
         if (!empty($value)) {
             // Handle a numeric value coming in (perhaps from a Number field)
             if (\is_numeric($value)) {
-                $config['value'] = (float)$value;
+                $config['value'] = $value;
             } elseif (\is_string($value)) {
                 $config = Json::decodeIfJson($value);
             }
             if (\is_array($value)) {
+                // TODO: why arrayfilter here?
                 $config = array_merge($config, array_filter($value));
             }
         }
-        // Typecast it to a float
-        $config['value'] = (float)$config['value'];
         // Create and validate the model
         $unitsData = new UnitsData($config);
         if (!$unitsData->validate()) {

--- a/src/fields/Units.php
+++ b/src/fields/Units.php
@@ -120,7 +120,7 @@ class Units extends Number implements PreviewableFieldInterface
     {
         $value = parent::normalizeValue($value, $element);
 
-        if ($value instanceof UnitsData) {
+        if ($value instanceof UnitsData || $value === null) {
             return $value;
         }
         // Default config

--- a/src/fields/Units.php
+++ b/src/fields/Units.php
@@ -163,13 +163,17 @@ class Units extends Number implements PreviewableFieldInterface
         $unitsClassMap = array_flip(ClassHelper::getClassesInNamespace(Length::class));
 
         // Render the settings template
-        return Craft::$app->getView()->renderTemplate(
+        $html = Craft::$app->getView()->renderTemplate(
             'units/_components/fields/Units_settings',
             [
                 'field' => $this,
                 'unitsClassMap' => $unitsClassMap,
             ]
         );
+
+        $html .=  parent::getSettingsHtml();
+
+        return $html;
     }
 
     /**

--- a/src/fields/Units.php
+++ b/src/fields/Units.php
@@ -99,18 +99,26 @@ class Units extends Field implements PreviewableFieldInterface
     public function init()
     {
         parent::init();
-        /** @var Settings $settings */
+
         if (UnitsPlugin::$plugin !== null) {
+            /** @var Settings $settings */
             $settings = UnitsPlugin::$plugin->getSettings();
+
             if (!empty($settings)) {
                 $this->defaultUnitsClass = $this->defaultUnitsClass ?? $settings->defaultUnitsClass;
-                $this->defaultValue = $this->defaultValue ?? $settings->defaultValue;
                 $this->defaultUnits = $this->defaultUnits ?? $settings->defaultUnits;
                 $this->changeableUnits = $this->changeableUnits ?? $settings->defaultChangeableUnits;
                 $this->min = $this->min ?? $settings->defaultMin;
                 $this->max = $this->max ?? $settings->defaultMax;
                 $this->decimals = $this->decimals ?? $settings->defaultDecimals;
-                $this->size = $this->size ?? $settings->defaultSize;
+
+                if ($this->defaultValue !== null && !$this->defaultValue) {
+                    $this->defaultValue = $settings->defaultValue;
+                }
+
+                if ($this->size !== null && !$this->size) {
+                    $this->size = $settings->defaultSize;
+                }
             }
         }
     }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -57,7 +57,7 @@ class Settings extends Model
     /**
      * @var int The default number of digits allowed after the decimal point
      */
-    public $defaultDecimals = 2;
+    public $defaultDecimals = 0;
 
     /**
      * @var int|null The default size of the field

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -10,9 +10,9 @@
 
 namespace nystudio107\units\models;
 
-use PhpUnitsOfMeasure\PhysicalQuantity\Length;
-
 use craft\base\Model;
+
+use PhpUnitsOfMeasure\PhysicalQuantity\Length;
 
 /**
  * @author    nystudio107
@@ -30,9 +30,9 @@ class Settings extends Model
     public $defaultUnitsClass = Length::class;
 
     /**
-     * @var float The default value of the unit of measure
+     * @var int|float|null The default value of the unit of measure
      */
-    public $defaultValue = 0.0;
+    public $defaultValue;
 
     /**
      * @var string The default units that the unit of measure is in
@@ -57,12 +57,12 @@ class Settings extends Model
     /**
      * @var int The default number of digits allowed after the decimal point
      */
-    public $defaultDecimals = 3;
+    public $defaultDecimals = 2;
 
     /**
      * @var int|null The default size of the field
      */
-    public $defaultSize = 6;
+    public $defaultSize;
 
     // Public Methods
     // =========================================================================
@@ -75,13 +75,9 @@ class Settings extends Model
         $rules = parent::rules();
         $rules = array_merge($rules, [
             ['defaultUnitsClass', 'string'],
-            ['defaultUnitsClass', 'default', 'value' => Length::class],
             ['defaultValue', 'number'],
-            ['defaultValue', 'default', 'value' =>  0.0],
             ['defaultUnits', 'string'],
-            ['defaultUnits', 'default', 'value' => 'ft'],
             ['defaultChangeableUnits', 'boolean'],
-            ['defaultChangeableUnits', 'default', 'value' => true],
             [['defaultMin', 'defaultMax'], 'number'],
             [
                 ['defaultMax'],
@@ -89,11 +85,7 @@ class Settings extends Model
                 'compareAttribute' => 'defaultMin',
                 'operator' => '>='
             ],
-            ['defaultMin', 'default', 'value' => 0],
-            ['defaultMax', 'default', 'value' => null],
             [['defaultDecimals', 'defaultSize'], 'integer'],
-            ['defaultDecimals', 'default', 'value' => 3],
-            ['defaultSize', 'default', 'value' => 6],
         ]);
 
         if (!$this->defaultDecimals) {

--- a/src/templates/_components/fields/Units_input.twig
+++ b/src/templates/_components/fields/Units_input.twig
@@ -20,26 +20,36 @@
 {% do view.registerAssetBundle("nystudio107\\units\\assetbundles\\units\\UnitsAsset") %}
 {% do view.registerAssetBundle("nystudio107\\units\\assetbundles\\unitsfield\\UnitsFieldAsset") %}
 
-{{ forms.textField({
-    id: id ~ "value",
-    name: name ~ "[value]",
-    value: value,
-    size: field.size,
-}) }}
-
-{% if field.changeableUnits %}
-    <div class="field units-field-units-select">
-    {{ forms.select({
-        id: id ~ "units",
-        name: name ~ "[units]",
-        options: craft.units.availableUnits(model.unitsClass),
-        value: model.units,
-    }) }}
-    </div>
-{% else %}
-    <div class="field units-field-units">
-        <div class="heading">
-            <p class="instructions">{{ field.defaultUnits }}</p>
+<div class="flex units-field">
+    {% if field.prefix %}
+        <div>
+            {{ field.prefix|md(inlineOnly=true)|raw }}
         </div>
+    {% endif %}
+    <div>
+        {{ forms.textField({
+            id: id ~ "value",
+            name: name ~ "[value]",
+            value: value,
+            size: field.size,
+            unit: not field.changeableUnits ? field.defaultUnits
+        }) }}
     </div>
-{% endif %}
+    <div>
+        {% if field.changeableUnits %}
+            <div class="field units-field-units-select">
+                {{ forms.select({
+                    id: id ~ "units",
+                    name: name ~ "[units]",
+                    options: craft.units.availableUnits(model.unitsClass),
+                    value: model.units,
+                }) }}
+            </div>
+        {% endif %}
+    </div>
+    {% if field.suffix %}
+        <div>
+            {{ field.suffix|md(inlineOnly=true)|raw }}
+        </div>
+    {% endif %}
+</div>

--- a/src/templates/_components/fields/Units_settings.twig
+++ b/src/templates/_components/fields/Units_settings.twig
@@ -28,15 +28,6 @@
     errors: field.getErrors("defaultUnitsClass"),
 }) }}
 
-{{ forms.textField({
-    label: "Default Value"|t("units"),
-    id: 'defaultValue',
-    name: 'defaultValue',
-    value: field.defaultValue,
-    size: 5,
-    errors: field.getErrors("defaultValue"),
-}) }}
-
 {{ forms.selectField({
     label: "Default Units"|t("units"),
     id: "defaultUnits",
@@ -53,43 +44,6 @@
     on: field.changeableUnits,
     errors: field.getErrors("changeableUnits"),
 }) }}
-
-{{ forms.textField({
-    label: "Min Value"|t('units'),
-    id: 'min',
-    name: 'min',
-    value: field.min,
-    size: 5,
-    errors: field.getErrors('min')
-}) }}
-
-{{ forms.textField({
-    label: "Max Value"|t('units'),
-    id: 'max',
-    name: 'max',
-    value: field.max,
-    size: 5,
-    errors: field.getErrors('max')
-}) }}
-
-{{ forms.textField({
-    label: "Decimal Points"|t('units'),
-    id: 'decimals',
-    name: 'decimals',
-    value: field.decimals,
-    size: 1,
-    errors: field.getErrors('decimals')
-}) }}
-
-{{ forms.textField({
-    label: "Size"|t('units'),
-    id: 'size',
-    name: 'size',
-    value: field.size,
-    size: 2,
-    errors: field.getErrors('size')
-}) }}
-
 
 {% js %}
     // Fill in the dynamic unit menu


### PR DESCRIPTION
Fixes #1, #3

Summary of changes:

- Field now directly extends `craft\fields\Number`, which removes a lot of duplicate code, allows `defaultValue` to be `null`, and gives us prefix/suffix.
- The matching field setting defaults now match `Number`:
    - `defaultValue` = `null`
    - `size` = `null`
    - `decimals` = `0`
- Input Template
  - Field now in a flex wrapper (like Number field) to lay things out horizontally
  - unit is displayed using `forms.textField`'s `unit` option